### PR TITLE
Json payload + source location

### DIFF
--- a/katip-raven.cabal
+++ b/katip-raven.cabal
@@ -17,6 +17,12 @@ extra-source-files:  CHANGELOG.md
 library
   exposed-modules:     Katip.Scribes.Raven
   default-extensions:  Rank2Types, OverloadedStrings
-  build-depends:       base ^>=4.12.0.0, aeson, text, katip, raven-haskell, string-conv, unordered-containers
+  build-depends:       base ^>=4.12.0.0
+                     , aeson
+                     , text
+                     , katip
+                     , raven-haskell >= 0.1.4.0
+                     , string-conv
+                     , unordered-containers
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Katip/Scribes/Raven.hs
+++ b/src/Katip/Scribes/Raven.hs
@@ -10,6 +10,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Katip
 import qualified System.Log.Raven as Raven
 import qualified System.Log.Raven.Types as Raven
+import Control.Arrow (first)
 
 
 mkRavenScribe :: Raven.SentryService -> Katip.PermitFunc -> Katip.Verbosity -> IO Katip.Scribe
@@ -28,9 +29,9 @@ mkRavenScribe sentryService permitItem verbosity = return $
         msg = show $ Katip._itemMessage item
         updateRecord record = record
             { Raven.srEnvironment = Just $ toS $ Katip.getEnvironment $ Katip._itemEnv item
-            , Raven.srTimestamp = show $ Katip._itemTime item
+            , Raven.srTimestamp = Katip._itemTime item
             -- add katip context as raven extras
-            , Raven.srExtra = extras $ Katip.payloadObject verbosity $ Katip._itemPayload item
+            , Raven.srExtra = HM.fromList $ map (first T.unpack) $ HM.toList $ Katip.payloadObject verbosity $ Katip._itemPayload item
             }
 
     sentryLevel :: Katip.Severity -> Raven.SentryLevel
@@ -45,6 +46,3 @@ mkRavenScribe sentryService permitItem verbosity = return $
 
     sentryName :: Katip.Namespace -> T.Text
     sentryName (Katip.Namespace xs) = T.intercalate "." xs
-
-    extras :: (HM.HashMap T.Text Aeson.Value -> HM.HashMap String String)
-    extras object = HM.fromList $ map (\(k, v) -> (toS k, toS (Aeson.encode v))) $ HM.toList object

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ resolver: lts-14.5
 packages:
 - .
 extra-deps:
-- raven-haskell-0.1.2.0
+- raven-haskell-0.1.4.0


### PR DESCRIPTION
This removes needless escaping from the sentry dashboard and presents the data in an even nicer way. Raw JSON is still available by clicking the [Formatted|Raw] button pair.
Also fixes #3 by updating raven-haskell and fixes #5 by adding primitive source location support.
